### PR TITLE
Changed package versions to beta2

### DIFF
--- a/src/Microsoft.Net.WebSocketAbstractions/project.json
+++ b/src/Microsoft.Net.WebSocketAbstractions/project.json
@@ -1,12 +1,12 @@
 {
-    "version": "1.0.0-*",
+    "version": "1.0.0-beta2",
     "description": "WebSocket abstract base class.",
     "frameworks": {
         "net45": { },
         "aspnetcore50": {
           "dependencies": {
-            "System.Runtime": "4.0.20-beta-*",
-            "System.Threading.Tasks": "4.0.10-beta-*"
+            "System.Runtime": "4.0.20-beta-22416",
+            "System.Threading.Tasks": "4.0.10-beta-22416"
           }
         }
     }


### PR DESCRIPTION
@Tratcher 

Just FYI...the Xunit packages are not available on public Nuget feed and we are figuring out if we need to create a separate feed for external packages, but other than that please take a look at the changes to other packages.