### PR TITLE
Using 'nameof' operator instead of magic strings

### DIFF
--- a/src/Microsoft.Net.WebSocketAbstractions/WebSocketReceiveResult.cs
+++ b/src/Microsoft.Net.WebSocketAbstractions/WebSocketReceiveResult.cs
@@ -44,7 +44,7 @@ namespace System.Net.WebSockets
         {
             if (count < 0)
             {
-                throw new ArgumentOutOfRangeException("count");
+                throw new ArgumentOutOfRangeException(nameof(count));
             }
             this.Count = count;
             this.EndOfMessage = endOfMessage;


### PR DESCRIPTION
Using the "nameof" operator instead of magic string will help us if the variable change in the future for whatever the reason